### PR TITLE
Add banker advisory outreach email template

### DIFF
--- a/EMAIL_TEMPLATES.md
+++ b/EMAIL_TEMPLATES.md
@@ -3,9 +3,87 @@
 ## Template Categories
 
 ### 1. Strategic Acquisition Templates
+
 **Target:** Large tech companies (Microsoft, Google, Amazon, etc.)
 
+#### Template A0: Banker Advisory Outreach (Tech M&A)
+
+```
+Subject: Bickford — AI execution & enforcement infrastructure (seeking acquisition guidance)
+
+Hi [Name],
+
+Thanks again for taking my call. As requested, here is a concise overview of Bickford and why I reached out.
+
+---
+
+What Bickford Is
+
+Bickford is execution and enforcement infrastructure for enterprise AI. It makes safety, governance, and policy constraints mechanically enforceable at runtime, with cryptographic auditability.
+
+---
+
+The Problem We Solve
+
+Every major AI platform now publishes safety principles:
+• Anthropic → Constitutional AI
+• OpenAI → safety & usage guidelines
+• Cloud providers → governance frameworks
+
+In regulated environments (DoD, healthcare, financial services), “the model was trained to be safe” is not sufficient. Regulators require provable enforcement:
+• What constraints applied
+• Who had authority
+• What decision was made
+• Why it complied
+• How it can be audited later
+
+Today’s approaches fall short:
+• Prompt engineering → unreliable
+• Post-hoc monitoring → too late
+• Human review → unscalable
+
+---
+
+What We’ve Built
+
+Bickford is not middleware or a workflow tool. It is a deterministic execution runtime that sits above AI models and agents and makes policy violations architecturally impossible.
+
+Core capabilities:
+• Deterministic execution runtime with enforced policy constraints
+• Cryptographic ledger binding intent → authorization → execution → audit
+• Canon-aware planning to prevent decision decay across teams and time
+• Automated compliance artifact generation (SOC 2, FedRAMP, NIST 800-53)
+
+The result is AI that can be safely deployed into high-consequence, regulated environments.
+
+---
+
+Why I Reached Out
+
+This does not feel like a traditional standalone SaaS or VC-scale GTM motion. The technical moat is real, but the buyer universe is strategic and narrow — foundation model companies or cloud platforms that need to sell AI into regulated markets.
+
+I’m seeking guidance on:
+1) Whether this category framing makes strategic sense
+2) Who the natural buyers are beyond the obvious names
+3) What a realistic acquisition process looks like given we are pre-revenue but technically complete
+
+---
+
+Current State
+• Production-ready TypeScript / Next.js implementation
+• Deterministic execution, audit, and replay already working
+• No revenue yet, but explicitly designed for federal and healthcare compliance
+• Solo founder with deep experience in AI governance and federal procurement
+
+Happy to walk through the system live or provide deeper technical detail if helpful.
+
+Best regards,
+Derek Bickford
+[Contact info]
+```
+
 #### Template A: Direct Executive Introduction
+
 ```
 Subject: Intent-to-Reality: Strategic Acquisition Opportunity for [Company]
 
@@ -34,6 +112,7 @@ Founder, Bickford Technologies LLC
 ```
 
 #### Template B: Technical Champion Approach
+
 ```
 Subject: Technical Deep Dive: Intent-to-Reality Architecture & [Company] Integration
 
@@ -57,9 +136,11 @@ Best,
 ```
 
 ### 2. Venture Capital Templates
+
 **Target:** VC firms and strategic investors
 
 #### Template C: Investment Opportunity
+
 ```
 Subject: $942B Market Opportunity: Intent-to-Reality Platform for Investment
 
@@ -93,9 +174,11 @@ Founder, Bickford Technologies LLC
 ```
 
 ### 3. Enterprise Partnership Templates
+
 **Target:** Large enterprises seeking competitive advantage
 
 #### Template D: Strategic Partnership
+
 ```
 Subject: Accelerate [Company]'s AI Transformation with Intent-to-Reality
 
@@ -122,6 +205,7 @@ Best,
 ### 4. Follow-Up Templates
 
 #### Template E: Post-Meeting Follow-Up
+
 ```
 Subject: Thank you for our discussion on Intent-to-Reality
 
@@ -146,6 +230,7 @@ Best regards,
 ```
 
 #### Template F: Value Proposition Reinforcement
+
 ```
 Subject: The Strategic Value of Intent-to-Reality for [Company]
 
@@ -167,6 +252,7 @@ Best,
 ### 5. Objection Handling Templates
 
 #### Template G: Addressing Budget Concerns
+
 ```
 Subject: Addressing Investment Concerns: Intent-to-Reality ROI
 
@@ -189,6 +275,7 @@ Best,
 ```
 
 #### Template H: Competitive Response
+
 ```
 Subject: Intent-to-Reality vs. Current Solutions
 
@@ -219,6 +306,7 @@ Best,
 ### 6. Closing Templates
 
 #### Template I: Proposal Introduction
+
 ```
 Subject: Intent-to-Reality Partnership Proposal for [Company]
 
@@ -241,6 +329,7 @@ Best,
 ```
 
 #### Template J: Final Call to Action
+
 ```
 Subject: Moving Forward with Intent-to-Reality
 
@@ -263,18 +352,21 @@ Best,
 ## Personalization Guidelines
 
 ### Research-Based Customization:
+
 1. **Company-Specific:** Reference recent announcements, challenges, or initiatives
 2. **Role-Specific:** Tailor messaging to executive vs. technical vs. business audience
 3. **Industry Context:** Connect to industry trends and competitive pressures
 4. **Personal Touch:** Mention specific achievements or interests when possible
 
 ### Timing Optimization:
+
 - **Initial Outreach:** Tuesday-Thursday mornings
 - **Follow-Ups:** 3-5 business days after initial contact
 - **Post-Meeting:** Within 24 hours
 - **Proposals:** Within 1 week of qualified interest
 
 ### Tracking and Analytics:
+
 - Use unique email signatures for tracking
 - Monitor open rates and responses
 - A/B test subject lines and messaging


### PR DESCRIPTION
### Motivation
- Provide a banker-optimized, advisory-focused outreach email for M&A advisors under the strategic acquisition templates to make outreach clearer and more actionable for tech bankers. 

### Description
- Add a new `Template A0: Banker Advisory Outreach (Tech M&A)` entry to `EMAIL_TEMPLATES.md` containing the rewritten, banker-focused email (subject, concise company overview, problem statement, capabilities, ask, and current state). 
- Keep the template advisory (seeking guidance, not salesy) and place it before the existing executive templates to surface it for banker workflows. 
- Change is content-only and limited to `EMAIL_TEMPLATES.md`.

### Testing
- Pre-commit hooks (formatting via `prettier` and repository pre-commit checks) ran automatically and passed. 
- TypeScript and automated tests were not run by the pre-commit hook (they were temporarily disabled); no runtime tests were executed for this content-only change. 
- Verified the new template exists by inspecting `EMAIL_TEMPLATES.md` (search for `Template A0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971501cdb80832c8deecb38f310f11b)