### PR TITLE
Replace 'Big Bird' with 'Bickford' in quantum decision doc

### DIFF
--- a/docs/QUANTUM_DECISION_ARCHITECTURE.md
+++ b/docs/QUANTUM_DECISION_ARCHITECTURE.md
@@ -1,0 +1,162 @@
+# Quantum Decision Architecture (Bickford Superposition)
+
+## 1) Intent
+
+Architect a decision system where **pre‑decision options exist in a superposition**, and **authority collapses** that superposition into an executable decision. Then model **decision decay** (the probability mass fades over time if no authority collapses it). The result is a marketable **Quantum Decision‑Making Runtime** for enterprise: faster TTV, explicit authority, and audit‑grade governance.
+
+## 2) Core Metaphor (Quantum → Enterprise Decisioning)
+
+| Quantum Mechanics                    | Enterprise Decisioning                                |
+| ------------------------------------ | ----------------------------------------------------- |
+| State vector \(\lvert \psi \rangle\) | Decision wavefront \(\Psi_t\) over admissible actions |
+| Superposition                        | Multiple candidate decisions with weights             |
+| Measurement                          | Authority enforcing one decision                      |
+| Collapse                             | Final, executable decision \(D\)                      |
+| Decoherence/decay                    | Stale decisions lose probability mass with time       |
+
+## 3) Formalization (Bickford‑compatible)
+
+### 3.1 Decision Superposition
+
+Let admissible actions at time \(t\) be \(A_t = \{a_1,\dots,a_n\}\), filtered by constraints \(\Theta\) and authority \(A\).
+
+Define a **decision superposition** over actions:
+
+\[
+\Psi*t = \sum*{k=1}^n \alpha_k(t) \lvert a_k \rangle,
+\quad \sum_k \lvert \alpha_k(t) \rvert^2 = 1
+\]
+
+**Interpretation:** \(\lvert \alpha_k(t) \rvert^2\) is the decision weight (probability mass) for action \(a_k\) given current signals, knowledge, and governance.
+
+### 3.2 Decision Collapse (Authority Enforcement)
+
+A **decision collapses** when authority is applied:
+
+\[
+\text{Collapse}:(\Psi_t,\sigma,\Theta) \rightarrow D=(I,R,E,\sigma)
+\]
+
+- \(\sigma\) is the authority signature.
+- The executed decision must satisfy **Execution Law**: \(a \in E \wedge \sigma \in A \wedge a \models \Theta\).
+
+### 3.3 Decision Decay (Superposition Loss)
+
+If no authority collapses the decision, decay reduces usability of the wavefront:
+
+\[
+\alpha_k(t+\Delta t) = \alpha_k(t) \cdot e^{-\lambda_k \Delta t}
+\]
+
+- \(\lambda_k\) is the **decision decay rate** (staleness risk, market drift, data aging).
+- Decay can be action‑specific (fast‑moving vs slow‑moving domains).
+
+### 3.4 OPTR‑Aligned Selection
+
+The optimal policy selects the action that minimizes expected **Time‑to‑Value**, respecting constraints:
+
+\[
+\pi^\* = \arg\min\_{\pi} \; \mathbb{E}[TTV(\pi)] \; \text{s.t.} \; \pi \models \Theta
+\]
+
+We can interpret **collapse selection** as:
+
+\[
+a^\* = \arg\max\_{a_k} \Big( \lvert \alpha_k(t) \rvert^2 \cdot e^{-\lambda_k \Delta t} \cdot U(a_k) \Big)
+\]
+
+Where \(U(a_k)\) encodes OPTR‑aligned value and risk weighting.
+
+## 4) Architecture: “Bickford Superposition Engine”
+
+**Bickford** is the system that maintains the decision superposition, predicts decay, and ensures authority‑bound collapse.
+
+### 4.1 Components
+
+1. **Wavefront Builder**
+   - Ingests signals, constraints \(\Theta\), and state \(s_t\).
+   - Produces candidate actions \(A_t\).
+
+2. **Amplitude Estimator**
+   - Assigns \(\alpha_k(t)\) using Bayesian or ensemble scoring.
+   - Encodes uncertainty directly into amplitude weights.
+
+3. **Decay Model**
+   - Computes \(\lambda_k\) and time‑sensitivity.
+   - Penalizes stale actions.
+
+4. **Authority Gate**
+   - Validates signatory \(\sigma\).
+   - Enforces \(a \models \Theta\).
+
+5. **Collapse Engine**
+   - Applies selection function, outputs executable \(D\).
+
+6. **Ledger & Proof**
+   - Writes \(D\) with hash to immutable ledger \(L\).
+   - Stores evidence of the superposition snapshot at collapse time.
+
+### 4.2 Data Flows
+
+1. **State ingestion → wavefront**
+2. **Wavefront → amplitude + decay**
+3. **Authority signature → collapse**
+4. **Decision → execution + ledger**
+5. **Observation → knowledge update**
+
+## 5) Decision Decay (Enterprise Narrative)
+
+**Claim:** _Decisions expire in value if not collapsed by authority._
+
+- New data shifts amplitudes.
+- Market conditions increase \(\lambda_k\).
+- Operational time‑lag kills ROI.
+
+**Outcome:** Enterprises need a system that **forces collapse** at the right time with the right authority, capturing maximum value before decay dominates.
+
+## 6) Enterprise Productization
+
+### 6.1 Value Claims
+
+- **Faster decision velocity** (collapse at the right moment).
+- **Reduced waste** (no stale approvals).
+- **Auditability** (ledgered collapse proof).
+- **Governance** (authority enforced at collapse).
+
+### 6.2 Deployment Model
+
+- **Decision Superposition API** for candidate generation.
+- **Authority Gateway** for approval and signature.
+- **Ledger Proof** for compliance and audit.
+
+## 7) Sales Story (Simple Pitch)
+
+> “Every enterprise decision exists in a superposition until authority collapses it. The longer you wait, the faster value decays. Bickford captures the wavefront, predicts decay, and collapses decisions at the optimal moment—fully governed and provable.”
+
+## 8) Mapping to Bickford Canonical Law
+
+- **Intent** → \(I=(G,\Theta,A,\tau)\)
+- **Superposition** → pre‑decision wavefront over admissible actions
+- **Decision** → \(D=(I,R,E,\sigma)\)
+- **Ledger** → \(L\) append‑only proof of collapse
+- **OPTR** → selects collapse minimizing expected TTV
+
+## 9) Decision Decay KPI
+
+Define **Decision Decay Loss (DDL)**:
+
+\[
+DDL = 1 - \frac{\max_k \big(\lvert\alpha_k(t)\rvert^2 e^{-\lambda_k \Delta t}\big)}{\max_k \lvert\alpha_k(t_0)\rvert^2}
+\]
+
+A high DDL means **value is being lost by delayed collapse**.
+
+## 10) Implementation Notes
+
+- The math is a **metaphor** for business: treat it as probabilistic decisioning with explicit time decay.
+- The ledger provides **enterprise‑grade audit** of collapse decisions.
+- The superposition representation enables **parallel evaluation** of competing actions.
+
+---
+
+**Result:** A fully governed, provable “quantum decision” architecture with measurable decay and enterprise‑grade collapse authority.


### PR DESCRIPTION
Intent
Replace all occurrences of “Big Bird” / “big bird” with “Bickford” in the quantum decision architecture document to align naming with the Bickford canonical language.

Contract
- Update `docs/QUANTUM_DECISION_ARCHITECTURE.md` to rename title, architecture component name, system references, and sales quote from Big Bird to Bickford.
- Preserve formatting and run a formatter check with `npx prettier --check docs/QUANTUM_DECISION_ARCHITECTURE.md`.

Proof
- `npx prettier --check docs/QUANTUM_DECISION_ARCHITECTURE.md` was executed and returned that all matched files use Prettier code style.
- The updated artifact is `docs/QUANTUM_DECISION_ARCHITECTURE.md` with the title, engine name, system reference line, and sales quote changed to “Bickford”.

Result
All visible references to Big Bird in the quantum decision architecture document have been replaced with Bickford and formatting was preserved according to Prettier.

Ledger
- Artifact: `docs/QUANTUM_DECISION_ARCHITECTURE.md` (updated).
- Verification command: `rg -n "Big Bird|big bird" docs/QUANTUM_DECISION_ARCHITECTURE.md` (should return no matches).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973781c25b4832c8b9840ec2b94a98a)